### PR TITLE
Simplify Buffer typing by extending instead of wrapping

### DIFF
--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -9,7 +9,7 @@ import {
   asciiReader,
   asciiWriter,
 } from '../'
-import { BufferWrapper, BufferBox } from '../types'
+import { BufferWrapper } from '../types'
 
 // lets override readers and writers so we can deal with ascii
 const readers = { 'char[]': asciiReader }
@@ -188,7 +188,7 @@ test('Bendec wrapper', t => {
   userAdd.user.uri.host = '1122334455'
   userAdd.user.uri.port = 123
 
-  let bufferBox = userAdd.getBuffer()
+  let typedBuffer = userAdd.getBuffer()
 
   let decoded = bendec.decode(buffer)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,14 +40,13 @@ export interface Config {
   getVariant: VariantGetter
 }
 
-export type BufferBox<T> = {
-  buffer: Buffer
+export interface TypedBuffer<T> extends Buffer {
   __phantom?: T
 }
 
 export interface IBufferWrapper<T> {
-  setBuffer(buffer: Buffer): BufferWrapper<T>
-  getBuffer(): BufferBox<T>
+  setBuffer(buffer: TypedBuffer<T>): BufferWrapper<T>
+  getBuffer(): TypedBuffer<T>
 }
 
 export type BufferWrapper<T> = T & IBufferWrapper<T>


### PR DESCRIPTION
Breaking change:
* instead of `wrapper.getBuffer().box` use just `wrapper.getBuffer()`
* `wrapper.setBuffer(buffer)` will not accept different `TypedBuffer` (but untyped `Buffer` can still be used)