### PR TITLE
Fix generators not updated for TypedBuffer

### DIFF
--- a/src/generators/wrap.ts
+++ b/src/generators/wrap.ts
@@ -51,7 +51,7 @@ const genWrapFunction = (readers, writers, lookup, name) => {
   let [write] = genReadFields(writers, lookup)(name)
 
   let setBuffer = `setBuffer(b) { buffer = b; return this }\n`
-  let getBuffer = `getBuffer() { return { buffer } }\n`
+  let getBuffer = `getBuffer() { return buffer }\n`
   let [content, construct] = genWrap(read, write)
     
   let constructWrap = `constructor() {\n` + 

--- a/src/generators/wrap2.ts
+++ b/src/generators/wrap2.ts
@@ -40,7 +40,7 @@ const genWrapFunction2 = (readers, writers, lookup, name) => {
   let [write] = genReadFields(writers, lookup)(name)
 
   let setBuffer = `setBuffer(b) { buffer = b; return this },\n`
-  let getBuffer = `getBuffer() { return { buffer } },\n`
+  let getBuffer = `getBuffer() { return buffer },\n`
   let all = genWrap2(read, write).join('') + setBuffer + getBuffer
 
   let body = `var buffer = buf\n` + 

--- a/src/generators/wrap3.ts
+++ b/src/generators/wrap3.ts
@@ -30,7 +30,7 @@ const genWrap = (read, write, path = []) => {
         `this.${k} = new (class ${k} {\n`,
           `${constructContent}\n`,
           `${gend}\n`,
-          `getBuffer() { return buffer.slice(${index}, ${nextIndex} - 1) }`,
+          `getBuffer() { return buffer.slice(${index}, ${nextIndex}) }`,
         `})\n`
       ].join(''))
 

--- a/src/generators/wrap3.ts
+++ b/src/generators/wrap3.ts
@@ -30,7 +30,7 @@ const genWrap = (read, write, path = []) => {
         `this.${k} = new (class ${k} {\n`,
           `${constructContent}\n`,
           `${gend}\n`,
-          `getBuffer() { return { buffer: buffer.slice(${index}, ${nextIndex - 1}) }}`,
+          `getBuffer() { return buffer.slice(${index}, ${nextIndex} - 1) }`,
         `})\n`
       ].join(''))
 
@@ -52,7 +52,7 @@ const genWrapFunction = (readers, writers, lookup, name) => {
   let [write] = genReadFields(writers, lookup)(name)
 
   let setBuffer = `setBuffer(b) { buffer = b; return this }\n`
-  let getBuffer = `getBuffer() { return { buffer } }\n`
+  let getBuffer = `getBuffer() { return buffer }\n`
   let [content, construct] = genWrap(read, write)
     
   let constructWrap = `constructor() {\n` + 

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -202,6 +202,28 @@ test('Bendec wrapper', t => {
   t.end()
 })
 
+test('Bendec wrapper slice', t => {
+
+  let size = bendec.getSize('UserAdd')
+  let buffer = Buffer.alloc(size)
+
+  let userAdd: BufferWrapper<UserAdd> = bendec.wrap('UserAdd', buffer)
+
+  userAdd.user.uri.protocol = 'https'
+  userAdd.user.uri.host = '127.0.0.1'
+  userAdd.user.uri.port = 666
+
+  let bufferSlice: Buffer = (<any>userAdd.user.uri).getBuffer()
+
+  t.deepEqual(
+    [...bufferSlice],
+    [...bendec.encodeAs(user.uri, 'Uri')],
+    'Uri slice read / encode'
+  )
+
+  t.end()
+})
+
 test('Bendec wrapper 2', t => {
 
   let size = bendec.getSize('UserAdd')

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -190,7 +190,7 @@ test('Bendec wrapper', t => {
 
   let typedBuffer = userAdd.getBuffer()
 
-  let decoded = bendec.decode(buffer)
+  let decoded = bendec.decode(typedBuffer)
 
   t.deepEqual({
     header: {


### PR DESCRIPTION
Fix too hasty merge of #1, where I missed some of the code I was extracting.

I also found a bug where wrapper missed one byte when returning buffer for nested object.