### PR TITLE
Make Rust bitflags explicitly transparent

### DIFF
--- a/src/tests/generated/rust/unions_enums.rs
+++ b/src/tests/generated/rust/unions_enums.rs
@@ -177,6 +177,7 @@ impl Animal2 {
 
 bitflags::bitflags! {
   #[derive(Serialize, Deserialize)]
+  #[repr(transparent)]
   pub struct Bitflags: u8 {
     const A    = 0b00000001;
     const B    = 0b00000010;

--- a/src/tools/rust/gen/bitflags.ts
+++ b/src/tools/rust/gen/bitflags.ts
@@ -46,6 +46,7 @@ export const getBitflags = (
 `bitflags::bitflags! {
   ${doc(description)}
   ${derivesString}
+  #[repr(transparent)]
   pub struct ${name}: ${underlying} {
 ${variantsFields}
   }


### PR DESCRIPTION
This PR essentially changes the output of the bitflag macro from:
```rs
struct MyBitflag {
    bits: u32,
}
```
to:
```rs
#[repr(transparent)]
struct MyBitflag {
    bits: u32,
}
```

While technically the chance of rust's single field struct ABI changing is low, it would be nice to explicitly state the layout of bitflag structs for the sake of correctness.

Another thing that comes to mind: maybe `#[serde(transparent)]` would be a good idea as well? (although I'm not adding it in this PR for the sake of not breaking all existing usage of serialize/deserialize)