### PR TITLE
Introduce JSON Scheme for Bendec JSON files

### DIFF
--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -1,0 +1,247 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/fudini/bendec/tree/master/src/assets/schema.json",
+  "title": "Bendec",
+  "description": "Schema for Bendec JSON typedef files",
+  "$defs": {
+    "Element": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Primitive"
+        },
+        {
+          "$ref": "#/$defs/Alias"
+        },
+        {
+          "$ref": "#/$defs/Struct"
+        },
+        {
+          "$ref": "#/$defs/Enum"
+        },
+        {
+          "$ref": "#/$defs/Union"
+        },
+        {
+          "$ref": "#/$defs/Array"
+        }
+      ]
+    },
+    "Kind": {
+      "type": "string",
+      "enum": [
+        "Primitive",
+        "Alias",
+        "Struct",
+        "Enum",
+        "Union",
+        "Array"
+      ]
+    },
+    "Primitive": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "Primitive",
+          "$ref": "#/$defs/Kind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "size": {
+          "type": "number"
+        }
+      }
+    },
+    "Alias": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "Alias",
+          "$ref": "#/$defs/Kind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "alias": {
+          "type": "string"
+        }
+      }
+    },
+    "Field": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "length": {
+          "type": "number",
+          "description": "length is specified it's an array"
+        }
+      }
+    },
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "Struct",
+          "$ref": "#/$defs/Kind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Field"
+          }
+        }
+      }
+    },
+    "Enum": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "Enum",
+          "$ref": "#/$defs/Kind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "underlying": {
+          "type": "string",
+          "description": "Underlying primitive type"
+        },
+        "offset": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "variants": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "string",
+                "description": "Name"
+              },
+              {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Value"
+              },
+              {
+                "type": "string",
+                "description": "Description"
+              }
+            ],
+            "items": false
+          }
+        },
+        "bitflags": {
+          "type": "boolean"
+        },
+        "implConst": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Union": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "Union",
+          "$ref": "#/$defs/Kind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "discriminator": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Array": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "Union",
+          "$ref": "#/$defs/Kind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "length": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "anyOf": [
+    {
+      "$ref": "#/$defs/Primitive"
+    },
+    {
+      "$ref": "#/$defs/Alias"
+    },
+    {
+      "$ref": "#/$defs/Struct"
+    },
+    {
+      "$ref": "#/$defs/Enum"
+    },
+    {
+      "$ref": "#/$defs/Union"
+    },
+    {
+      "$ref": "#/$defs/Array"
+    }
+  ]
+}


### PR DESCRIPTION
Simple schema for autocompletion and validation in code editors (VS, InteliJ, Vim with json-lsp).

This schema defines the layout of a single Bendec type, one is expected to reference to it in their schema.

For example, this is how one would annotate that Bendec types are expected in an array under `typeDefinitions` key:

`./schema.json`
```json
{
  "$schema": "https://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "typeDefinitions": {
      "type": "array",
      "items": {
        "$ref": "https://raw.githubusercontent.com/PolyMeilex/bendec/json-scheme/src/assets/schema.json"
      }
    }
  }
}
```
`./types.json`
```json
{
  "$schema": "./schema.json",
  "typeDefinitions": [
    {
      "kind": "Primitive",
      "name": "Abc",
      "size": 8
    }
  ]
}
```
From now on one's editor should pick the types up:
![image](https://github.com/fudini/bendec/assets/20758186/55550c63-569f-4078-b92d-b28694e76818)

