### PR TITLE
Fix typo in schema.json

### DIFF
--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -206,7 +206,7 @@
       "type": "object",
       "properties": {
         "kind": {
-          "const": "Union",
+          "const": "Array",
           "$ref": "#/$defs/Kind"
         },
         "name": {


### PR DESCRIPTION
My bad, did a typo in Array definition. Arrays should not be defined with kind "Union" :smile: 