### PR TITLE
Enum default and union derives

### DIFF
--- a/src/tests/generated/rust/unions_enums.rs
+++ b/src/tests/generated/rust/unions_enums.rs
@@ -8,16 +8,12 @@ pub use super::shared::*;
 // primitive built-in: u16
 
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub enum AnimalKind {
   /// This is a zebra
+  #[default]
   Zebra = 0x1001,
   Toucan = 0x1002,
-}
-impl Default for AnimalKind {
-  fn default() -> Self {
-    Self::Zebra
-  }
 }
 impl std::convert::TryFrom<u16> for AnimalKind {
   type Error = EnumValueError;
@@ -52,6 +48,7 @@ pub struct Toucan {
   pub wingspan: u16,
 }
 
+#[derive(Copy, Clone)]
 pub union Animal {
   pub zebra: Zebra,
   pub toucan: Toucan,
@@ -93,15 +90,11 @@ impl Animal {
 }
 
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, ExtraDerive)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Default, ExtraDerive)]
 pub enum AnimalKind2 {
+  #[default]
   Zebra2 = 0x0001,
   Toucan2 = 0x0002,
-}
-impl Default for AnimalKind2 {
-  fn default() -> Self {
-    Self::Zebra2
-  }
 }
 impl std::convert::TryFrom<u8> for AnimalKind2 {
   type Error = EnumValueError;

--- a/src/tests/typeGenerator.ts
+++ b/src/tests/typeGenerator.ts
@@ -86,6 +86,8 @@ test('Rust - unions and enums', t => {
     extraDerives: {
       'Zebra': ['Copy', 'Clone'],
       'AnimalKind2': ['ExtraDerive'],
+      // Union test
+      'Animal': ['Copy', 'Clone'],
     },
     enumConversionError: {
       type: 'EnumValueError',

--- a/src/tools/rsGenerator.ts
+++ b/src/tools/rsGenerator.ts
@@ -93,7 +93,7 @@ export const generateString = (
     }
 
     if (typeDef.kind === Kind.Union) {
-      return [getUnion(typeDef, types, typeMeta), context]
+      return [getUnion(typeDef, types, typeMeta, extraDerivesArray), context]
     }
 
     if (typeDef.kind === Kind.Enum) {

--- a/src/tools/rust/gen/enum.ts
+++ b/src/tools/rust/gen/enum.ts
@@ -30,7 +30,17 @@ export const getEnum = (
   }
 
   const variantsFields = variants
-    .map(([key, value, docs]) => smoosh([doc(docs, 2),`  ${key} = ${hexPad(value)},`]))
+    .map(([key, value, docs], i) => {
+      // first variant is a default (by default)
+      const defaultAnnotation = i == 0 ? '#[default]' : ''
+      return smoosh(
+        [
+          doc(docs, 2),
+          defaultAnnotation,
+          `  ${key} = ${hexPad(value)},`
+        ]
+      )
+    })
     .join('\n')
 
   const derivesString = createDerives([
@@ -45,13 +55,6 @@ ${derivesString}
 pub enum ${name} {
 ${variantsFields}
 }`])
-
-  const [firstVariantName] = variants[0]
-  const implDefault = `impl Default for ${name} {
-  fn default() -> Self {
-    Self::${firstVariantName}
-  }
-}`
 
   const implConstIntValues = variants
     .map(([key, value]) => `  pub const ${key}: ${underlying} = ${hexPad(value)};`)
@@ -86,7 +89,7 @@ ${variantsFieldsRev}
   }
 
   const implTryFromUnderlying = implTryFrom(underlying)
-  var impls = [enumBody, implDefault, implTryFromUnderlying]
+  var impls = [enumBody, implTryFromUnderlying]
 
   if (meta.implConst) {
     impls.push(implConstInt)

--- a/src/tools/rust/utils.ts
+++ b/src/tools/rust/utils.ts
@@ -26,7 +26,7 @@ export const createDerives = (derives: string[]): string => {
 
 export const defaultDerives: DefaultDerives = {
   struct: ['Serialize', 'Deserialize'],
-  enum: ['Debug', 'Copy', 'Clone', 'Eq', 'PartialEq', 'Serialize', 'Deserialize'],
+  enum: ['Debug', 'Copy', 'Clone', 'Eq', 'PartialEq', 'Serialize', 'Deserialize', 'Default'],
   bitflags: ['Serialize', 'Deserialize'],
   newtype: [],
 }


### PR DESCRIPTION
Modernize default variant on enums in Rust code and add an option to add custom derives to unions.